### PR TITLE
nvidia-drm-kmod: expand the comment and description

### DIFF
--- a/graphics/nvidia-drm-kmod/Makefile
+++ b/graphics/nvidia-drm-kmod/Makefile
@@ -3,7 +3,7 @@ PORTVERSION=	${NVIDIA_DISTVERSION}
 CATEGORIES=	graphics kld
 
 MAINTAINER=	ashafer@badland.io
-COMMENT=	NVIDIA DRM Kernel Module
+COMMENT=	Meta port of DRM kernel module for NVIDIA graphics hardware
 WWW=		https://github.com/amshafer/nvidia-driver
 
 USES=		metaport

--- a/graphics/nvidia-drm-kmod/pkg-descr
+++ b/graphics/nvidia-drm-kmod/pkg-descr
@@ -1,12 +1,15 @@
 FreeBSD port of Linux's nvidia-drm.ko Kernel module.
 
-nvidia-drm.ko complements the x11/nvidia-driver series of ports. It provides
-support for the DRM graphics subsystem, which can then be used by userspace
-applications.  This is primarily useful for PRIME render offload and Wayland
-compositors.
+nvidia-drm.ko complements the x11/nvidia-driver port. It provides support for
+the DRM graphics subsystem, which can then be used by userspace applications.
+This is primarily useful for PRIME render offload and Wayland compositors.
 
 NVIDIA's 525.⋯ series of drivers was the first with full support for
 nvidia-drm.
+
+x11/nvidia-driver was version 535.98_1 when graphics/nvidia-drm-kmod was added
+to the FreeBSD ports tree.  x11/nvidia-driver-470 and inferior versions lack
+the requisite support.
 
 On FreeBSD 13.1-RELEASE and greater: this meta port will automatically install
 the port of the recommended version of nvidia-drm.ko.

--- a/graphics/nvidia-drm-kmod/pkg-descr
+++ b/graphics/nvidia-drm-kmod/pkg-descr
@@ -1,1 +1,2 @@
-FreeBSD port of Linux's nvidia-drm.ko Kernel module.
+On FreeBSD 13.1-RELEASE and greater: this meta port will automatically install
+the recommended version of the port of Linux's nvidia-drm.ko kernel module.

--- a/graphics/nvidia-drm-kmod/pkg-descr
+++ b/graphics/nvidia-drm-kmod/pkg-descr
@@ -1,9 +1,13 @@
-On FreeBSD 13.1-RELEASE and greater: this meta port will automatically install
-the recommended version of the port of Linux's nvidia-drm.ko kernel module for
-NVIDIA graphics hardware.
+FreeBSD port of Linux's nvidia-drm.ko Kernel module.
+
+graphics/nvidia-drm is an alternative to the x11/nvidia-driver series of ports.
+
+nvidia-drm.ko provides support for the DRM graphics subsystem, which can then
+be used by userspace applications.  This is primarily useful for PRIME render
+offload and Wayland compositors.
 
 NVIDIA's 525.⋯ series of drivers was the first with full support for
 nvidia-drm.
 
-graphics/nvidia-drm is a Direct Rendering Manager (DRM) alternative to the
-x11/nvidia-driver series of ports. 
+On FreeBSD 13.1-RELEASE and greater: this meta port will automatically install
+the port of the recommended version of nvidia-drm.ko.

--- a/graphics/nvidia-drm-kmod/pkg-descr
+++ b/graphics/nvidia-drm-kmod/pkg-descr
@@ -1,6 +1,9 @@
 On FreeBSD 13.1-RELEASE and greater: this meta port will automatically install
-the recommended version of the port of Linux's nvidia-drm.ko kernel module for NVIDIA graphics hardware.
+the recommended version of the port of Linux's nvidia-drm.ko kernel module for
+NVIDIA graphics hardware.
 
-NVIDIA's 525.⋯ series of drivers was the first with full support for nvidia-drm.
+NVIDIA's 525.⋯ series of drivers was the first with full support for
+nvidia-drm.
 
-graphics/nvidia-drm is a Direct Rendering Manager (DRM) alternative to the x11/nvidia-driver series of ports. 
+graphics/nvidia-drm is a Direct Rendering Manager (DRM) alternative to the
+x11/nvidia-driver series of ports. 

--- a/graphics/nvidia-drm-kmod/pkg-descr
+++ b/graphics/nvidia-drm-kmod/pkg-descr
@@ -1,2 +1,6 @@
 On FreeBSD 13.1-RELEASE and greater: this meta port will automatically install
-the recommended version of the port of Linux's nvidia-drm.ko kernel module.
+the recommended version of the port of Linux's nvidia-drm.ko kernel module for NVIDIA graphics hardware.
+
+NVIDIA's 525.⋯ series of drivers was the first with full support for nvidia-drm.
+
+graphics/nvidia-drm is a Direct Rendering Manager (DRM) alternative to the x11/nvidia-driver series of ports. 

--- a/graphics/nvidia-drm-kmod/pkg-descr
+++ b/graphics/nvidia-drm-kmod/pkg-descr
@@ -1,10 +1,9 @@
 FreeBSD port of Linux's nvidia-drm.ko Kernel module.
 
-graphics/nvidia-drm is an alternative to the x11/nvidia-driver series of ports.
-
-nvidia-drm.ko provides support for the DRM graphics subsystem, which can then
-be used by userspace applications.  This is primarily useful for PRIME render
-offload and Wayland compositors.
+nvidia-drm.ko complements the x11/nvidia-driver series of ports. It provides
+support for the DRM graphics subsystem, which can then be used by userspace
+applications.  This is primarily useful for PRIME render offload and Wayland
+compositors.
 
 NVIDIA's 525.⋯ series of drivers was the first with full support for
 nvidia-drm.


### PR DESCRIPTION
```text
Clarify that graphics/nvidia-drm-kmod is a meta port (not a module in itself).

Note that nvidia-drm.ko complements (non-DRM) x11/nvidia-driver.

Add context: DRM graphics subsystem.

https://bugs.freebsd.org/273311

PR: 273311

Signed-off-by: Graham Perrin <grahamperrin@gmail.com>
```