### PR TITLE
sysutils/zfs-stats/Makefile: WWW for the fork

### DIFF
--- a/sysutils/zfs-stats/Makefile
+++ b/sysutils/zfs-stats/Makefile
@@ -5,7 +5,7 @@ CATEGORIES=	sysutils
 
 MAINTAINER=	mm@FreeBSD.org
 COMMENT=	Displays general ZFS information and human-readable statistics
-WWW=		https://www.vx.sk/zfs-stats/
+WWW=		https://github.com/mmatuska/zfs-stats
 
 LICENSE=	BSD2CLAUSE
 


### PR DESCRIPTION
Since we lost sight of the fact that this port is of a fork, it is no longer
appropriate to use the original (non-fork) URL for WWW purposes.

Instead, use the URL of the fork.

https://bugs.freebsd.org/258238

PR: 258238
Fixes: 8ab46275a6c0 sysutils/zfs-stats: Remove obsolete shebangfix and update pkg-descr