### PR TITLE
emulators/virtualbox-ose-legacy family, including www/phpvirtualbox-legacy: deprecate six legacy ports

### DIFF
--- a/emulators/virtualbox-ose-additions-legacy/Makefile
+++ b/emulators/virtualbox-ose-additions-legacy/Makefile
@@ -13,6 +13,9 @@ WWW=		https://www.virtualbox.org/
 LICENSE=	GPLv2
 LICENSE_FILE=	${WRKSRC}/COPYING
 
+DEPRECATED=     Upstream support for VirtualBox 5.x ended in 2020. Please use the non-legacy ports of VirtualBox software.
+EXPIRATION_DATE=2023-11-05
+
 ONLY_FOR_ARCHS=	amd64 i386
 USES=		compiler:c++11-lang cpe iconv kmod tar:bzip2
 USE_RC_SUBR=	vboxguest vboxservice

--- a/emulators/virtualbox-ose-kmod-legacy/Makefile
+++ b/emulators/virtualbox-ose-kmod-legacy/Makefile
@@ -13,6 +13,9 @@ WWW=		https://www.virtualbox.org/
 LICENSE=	GPLv2
 LICENSE_FILE=	${WRKSRC}/COPYING
 
+DEPRECATED=     Upstream support for VirtualBox 5.x ended in 2020. Please use the non-legacy ports of VirtualBox software.
+EXPIRATION_DATE=2023-11-05
+
 BUILD_DEPENDS=	kmk:devel/kBuild
 
 CPE_VENDOR=	oracle

--- a/emulators/virtualbox-ose-legacy/Makefile
+++ b/emulators/virtualbox-ose-legacy/Makefile
@@ -14,6 +14,9 @@ WWW=		https://www.virtualbox.org/
 LICENSE=	GPLv2
 LICENSE_FILE=	${WRKSRC}/COPYING
 
+DEPRECATED=     Upstream support VirtualBox 5.x ended in 2020. Please use the non-legacy ports of VirtualBox software.
+EXPIRATION_DATE=2023-11-05
+
 ONLY_FOR_ARCHS=	amd64 i386
 
 PATCH_DEPENDS+=	${LOCALBASE}/share/kBuild/tools/GXX3.kmk:devel/kBuild

--- a/www/phpvirtualbox-legacy/Makefile
+++ b/www/phpvirtualbox-legacy/Makefile
@@ -10,6 +10,9 @@ WWW=		https://sourceforge.net/projects/phpvirtualbox/
 
 LICENSE=	GPLv3
 
+DEPRECATED=     Upstream support for VirtualBox 5.x ended in 2020. Please use non-legacy www/phpvirtualbox 6.1_2 or greater.
+EXPIRATION_DATE=2023-11-05
+
 USES=		dos2unix php
 USE_PHP=	session simplexml soap xml
 


### PR DESCRIPTION
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=274270