### PR TITLE
games/mizuma: describe usability with KDE Plasma

### DIFF
--- a/games/mizuma/Makefile
+++ b/games/mizuma/Makefile
@@ -4,7 +4,7 @@ CATEGORIES=	games emulators
 MASTER_SITES=	https://codeberg.org/Alexander88207/Mizutamari/archive/${PORTVERSION}${EXTRACT_SUFX}?dummy=/
 
 MAINTAINER=	Alexander88207@protonmail.com
-COMMENT=	Wine front-end for FreeBSD
+COMMENT=	Mizutamari is a user-friendly front end to Wine, including Winetricks
 WWW=		https://codeberg.org/Alexander88207/Mizutamari
 
 LICENSE=	BSD2CLAUSE

--- a/games/mizuma/pkg-descr
+++ b/games/mizuma/pkg-descr
@@ -1,2 +1,19 @@
-Mizutamari is a launcher that aims to help you run a list
-of applications in Wine with a few simple clicks on FreeBSD.
+Mizutamari is a user-friendly front end to Wine. Wine allows various
+applications for Windows to be used with alternative operating systems,
+such as FreeBSD.
+
+Mizutamari features include:
+
+- installation
+- launcher
+- uninstallation
+- Winetricks
+- kill Wine in a selected prefix
+- open Mizutamari folder.
+
+To use Mizutamari with KDE Plasma on FreeBSD: 
+
+- you must build games/mizuma to use glxinfo from mesa-demos. 
+
+(The default, glxinfo from glx-utils, indirectly conflicts with ports
+such as sysutils/plasma5-kinfocenter and sysutils/plasma6-kinfocenter.)


### PR DESCRIPTION
Expand the package description with advice about glxinfo from glx-utils
indirectly conflicting with KDE ports such as plasma5-kinfocenter and
plasma6-kinfocenter.

Whilst here, enhance the existing description to:

- describe Wine, in a nutshell
- describe the features of Mizutamari that are currently pictured at
  its home page.

Add the name of the application to the comment for the port.